### PR TITLE
Fix duplicate import in webcam test

### DIFF
--- a/tests/test_webcam.py
+++ b/tests/test_webcam.py
@@ -36,8 +36,6 @@ sys.modules['flask'] = flask_stub
 spec = importlib.util.spec_from_file_location('webcam', 'webcam.py')
 webcam = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(webcam)
-
-from unittest import mock
 import subprocess
 
 def test_auto_detect_camera_ids_found():


### PR DESCRIPTION
## Summary
- remove redundant `mock` import from tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdbff5bac8333abebfc496647942c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Cleaned up redundant import statements in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->