### PR TITLE
Add requirements, rotating logs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ ffmpeg, v4l2loopback, OpenCV, and Flask.
 - OpenCV (`cv2`)
 - Flask
 
+Python dependencies can be installed with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Usage
 
 ```bash
@@ -20,6 +26,9 @@ python3 webcam.py [--port PORT] [--start|--stop|--install|--uninstall]
                   [--vendor VENDOR_ID] [--product PRODUCT_ID]
                   [--log-file PATH]
 ```
+
+Most operations interact with system modules and may require root privileges.
+Use `sudo` when necessary.
 
 Running the script without arguments is the same as `--start`.
 Default port: **9007**.
@@ -33,11 +42,12 @@ python3 webcam.py --start
 ### Install as a service
 
 ```bash
-python3 webcam.py --install --vendor <VENDOR_ID> --product <PRODUCT_ID>
+sudo python3 webcam.py --install --vendor <VENDOR_ID> --product <PRODUCT_ID>
 ```
 
-If vendor and product IDs are not provided, the script attempts to detect them
-with `lsusb`.
+Installing the service writes udev rules and therefore requires root
+permissions. If vendor and product IDs are not provided, the script attempts to
+detect them with `lsusb`.
 
 ### Stop the service
 
@@ -48,7 +58,7 @@ python3 webcam.py --stop
 ### Uninstall
 
 ```bash
-python3 webcam.py --uninstall
+sudo python3 webcam.py --uninstall
 ```
 
 ## Web Interface
@@ -60,7 +70,7 @@ The endpoint `/image` returns the latest frame as a JPEG.
 
 By default logs are written to `./webcam.log`. You can change the location with
 the `--log-file` command-line option or the `WEBCAM_LOG_PATH` environment
-variable.
+variable. Logs rotate automatically when they reach about 1&nbsp;MB.
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+opencv-python

--- a/tests/test_webcam.py
+++ b/tests/test_webcam.py
@@ -59,3 +59,17 @@ def test_kill_existing_processes():
             m_run.assert_any_call(['sudo', 'kill', '-9', '1234'])
             m_run.assert_any_call(['sudo', 'kill', '-9', '5678'])
 
+
+def test_index_uses_template():
+    with mock.patch.object(webcam, 'render_template_string', return_value="") as m_render:
+        assert webcam.index() == ""
+        assert m_render.called
+
+
+def test_image_no_frame_calls_abort():
+    webcam.frame_buffer = None
+    webcam.frame_buffer_time = 0
+    with mock.patch.object(webcam, 'abort') as m_abort:
+        webcam.image()
+        m_abort.assert_called_once_with(404)
+

--- a/webcam.py
+++ b/webcam.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 import time
 import logging
+from logging.handlers import RotatingFileHandler
 import cv2
 from flask import Flask, Response, abort, render_template_string
 import argparse
@@ -21,6 +22,16 @@ frame_buffer_time = None
 # Path to the log file. This will be configured in ``main`` based on
 # command-line arguments or environment variables.
 LOG_PATH = None
+
+
+def configure_logging(path):
+    """Configure rotating file logging."""
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    handler = RotatingFileHandler(path, maxBytes=1_000_000, backupCount=3)
+    formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
 def setup_camera():
     """Set up camera module and other dependencies."""
@@ -308,9 +319,7 @@ def main():
 
     global LOG_PATH
     LOG_PATH = args.log_file or os.environ.get('WEBCAM_LOG_PATH') or './webcam.log'
-    logging.basicConfig(filename=LOG_PATH,
-                        level=logging.INFO,
-                        format='%(asctime)s:%(levelname)s:%(message)s')
+    configure_logging(LOG_PATH)
     logging.info('Webcam script started')
 
     # Determine vendor and product IDs


### PR DESCRIPTION
## Summary
- document Python requirements and usage notes
- improve instructions for installing/uninstalling the service
- rotate log file via `configure_logging`
- test Flask route helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408c9fa6288333b915247e570107ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with clearer installation instructions, sudo usage guidance, and expanded details on service installation, device detection, and log rotation behavior.

- **Chores**
  - Added a requirements file specifying necessary Python dependencies.

- **Tests**
  - Introduced tests to verify template rendering and error handling in the application.

- **Refactor**
  - Improved logging setup to use automatic log file rotation for better log management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->