### PR TITLE
Add configurable gphoto2/ffmpeg paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 ```bash
 python3 webcam.py [--port PORT] [--start|--stop|--install|--uninstall]
                   [--vendor VENDOR_ID] [--product PRODUCT_ID]
-                  [--log-file PATH]
+                  [--log-file PATH] [--gphoto2 PATH] [--ffmpeg PATH]
 ```
 
 Most operations interact with system modules and may require root privileges.
@@ -71,6 +71,12 @@ The endpoint `/image` returns the latest frame as a JPEG.
 By default logs are written to `./webcam.log`. You can change the location with
 the `--log-file` command-line option or the `WEBCAM_LOG_PATH` environment
 variable. Logs rotate automatically when they reach about 1&nbsp;MB.
+
+## Executable Paths
+
+If `gphoto2` or `ffmpeg` are not installed in standard locations, provide their
+paths with the `--gphoto2` and `--ffmpeg` options. The environment variables
+`GPHOTO2_PATH` and `FFMPEG_PATH` can also be used to override the defaults.
 
 ## License
 

--- a/tests/test_webcam.py
+++ b/tests/test_webcam.py
@@ -73,3 +73,22 @@ def test_image_no_frame_calls_abort():
         webcam.image()
         m_abort.assert_called_once_with(404)
 
+
+def test_setup_camera_uses_config_paths():
+    gphoto_mock = mock.Mock(stdout='out', stderr=mock.Mock())
+    ffmpeg_mock = mock.Mock(stderr=mock.Mock())
+    with mock.patch.object(webcam.subprocess, 'run'):
+        with mock.patch.object(webcam.subprocess, 'Popen') as m_popen, \
+             mock.patch.object(webcam.threading, 'Thread'):
+            m_popen.side_effect = [gphoto_mock, ffmpeg_mock]
+            webcam.GPHOTO2_PATH = '/opt/gphoto2'
+            webcam.FFMPEG_PATH = '/opt/ffmpeg'
+            webcam.setup_camera()
+            m_popen.assert_any_call([
+                '/opt/gphoto2', '--stdout', '--capture-movie'
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            m_popen.assert_any_call([
+                '/opt/ffmpeg', '-i', '-', '-pix_fmt', 'yuv420p', '-f', 'v4l2', '/dev/video0'
+            ], stdin=gphoto_mock.stdout, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+

--- a/webcam.py
+++ b/webcam.py
@@ -19,9 +19,13 @@ ffmpeg_process = None
 frame_buffer = None
 frame_buffer_time = None
 
-# Path to the log file. This will be configured in ``main`` based on
-# command-line arguments or environment variables.
+# Paths configured at runtime via command-line arguments or environment
+# variables.  ``LOG_PATH`` is set in ``main`` as before.  ``GPHOTO2_PATH`` and
+# ``FFMPEG_PATH`` default to the traditional system locations but may be
+# overridden.
 LOG_PATH = None
+GPHOTO2_PATH = '/usr/bin/gphoto2'
+FFMPEG_PATH = '/usr/bin/ffmpeg'
 
 
 def configure_logging(path):
@@ -43,17 +47,17 @@ def setup_camera():
     subprocess.run(['sudo', 'modprobe', 'v4l2loopback', 'devices=1', 'exclusive_caps=1'], check=True)
 
     try:
-        # Start gphoto2 process
+        # Start gphoto2 process using configured path
         gphoto2_process = subprocess.Popen(
-            ['/usr/bin/gphoto2', '--stdout', '--capture-movie'],
+            [GPHOTO2_PATH, '--stdout', '--capture-movie'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
         logging.info('gphoto2 process started')
 
-        # Start ffmpeg process
+        # Start ffmpeg process using configured path
         ffmpeg_process = subprocess.Popen(
-            ['/usr/bin/ffmpeg', 
+            [FFMPEG_PATH,
                 #'-reconnect', '1', '-reconnect_at_eof', '1',
                 #'-reconnect_streamed', '1', '-reconnect_delay_max', '2',
                 #'-fflags', 'nobuffer',
@@ -314,11 +318,15 @@ def main():
     parser.add_argument('--vendor', type=str, help='USB Vendor ID of the camera')
     parser.add_argument('--product', type=str, help='USB Product ID of the camera')
     parser.add_argument('--log-file', type=str, help='Path to log file')
+    parser.add_argument('--gphoto2', type=str, help='Path to gphoto2 executable')
+    parser.add_argument('--ffmpeg', type=str, help='Path to ffmpeg executable')
 
     args = parser.parse_args()
 
-    global LOG_PATH
+    global LOG_PATH, GPHOTO2_PATH, FFMPEG_PATH
     LOG_PATH = args.log_file or os.environ.get('WEBCAM_LOG_PATH') or './webcam.log'
+    GPHOTO2_PATH = args.gphoto2 or os.environ.get('GPHOTO2_PATH') or GPHOTO2_PATH
+    FFMPEG_PATH = args.ffmpeg or os.environ.get('FFMPEG_PATH') or FFMPEG_PATH
     configure_logging(LOG_PATH)
     logging.info('Webcam script started')
 


### PR DESCRIPTION
## Summary
- allow callers to pass paths to `gphoto2` and `ffmpeg`
- document new flags in README
- add test covering configurable paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686014cbb24c83339410c693354a3364