### PR TITLE
Add Codecov coverage upload to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,31 @@
-name: Python package
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-    - name: Run tests
-      run: pytest -q
+        pip install -r requirements.txt
+        pip install pytest pytest-cov
+    - name: Run tests with coverage
+      run: pytest --cov=webcam --cov-report=xml
+    - name: Upload coverage
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.xml
 


### PR DESCRIPTION
## Summary
- update CI workflow to test against Python 3.10–3.12
- measure coverage with pytest-cov
- upload coverage report via Codecov action using `CODECOV_TOKEN`

## Testing
- `pytest -q`
- `pytest --cov=webcam --cov-report=xml` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6865b3ca304883338c910df5637334dc