### PR TITLE
Fix webcam module path in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ sudo apt install gphoto2 ffmpeg v4l2loopback-dkms
 Run the script without arguments to start streaming:
 
 ```bash
-python3 webcam.py
+python3 webcam
 ```
 
 The script accepts several options:
 
 ```bash
-python3 webcam.py [--port PORT] [--start|--stop|--install|--uninstall]
+python3 webcam [--port PORT] [--start|--stop|--install|--uninstall]
                   [--vendor VENDOR_ID] [--product PRODUCT_ID]
                   [--vendor-pattern REGEX]
                   [--log-file PATH] [--gphoto2 PATH] [--ffmpeg PATH]
@@ -64,7 +64,7 @@ Install the webcam service so that it starts automatically when the
 camera is plugged in:
 
 ```bash
-sudo python3 webcam.py --install --vendor <VENDOR_ID> --product <PRODUCT_ID>
+sudo python3 webcam --install --vendor <VENDOR_ID> --product <PRODUCT_ID>
 ```
 
 To stop the service or remove the udev rule use `--stop` and

--- a/tests/test_webcam.py
+++ b/tests/test_webcam.py
@@ -1,3 +1,4 @@
+import importlib.machinery
 import importlib.util
 import subprocess
 import sys
@@ -50,7 +51,8 @@ sys.modules["cv2"] = cv2_stub
 sys.modules["flask"] = flask_stub
 
 
-spec = importlib.util.spec_from_file_location("webcam", "webcam.py")
+loader = importlib.machinery.SourceFileLoader("webcam", "./webcam")
+spec = importlib.util.spec_from_file_location("webcam", "./webcam", loader=loader)
 webcam = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(webcam)
 
@@ -290,7 +292,7 @@ def test_monitor_gphoto_output_no_cleanup_on_info():
 
 
 def test_main_install_invokes_install_service():
-    argv = ["webcam.py", "--install", "--vendor", "1", "--product", "2"]
+    argv = ["webcam", "--install", "--vendor", "1", "--product", "2"]
     with (
         mock.patch.object(sys, "argv", argv),
         mock.patch.object(webcam, "configure_logging"),
@@ -303,7 +305,7 @@ def test_main_install_invokes_install_service():
 
 
 def test_main_uninstall_invokes_uninstall_service():
-    argv = ["webcam.py", "--uninstall", "--port", "1234"]
+    argv = ["webcam", "--uninstall", "--port", "1234"]
     with (
         mock.patch.object(sys, "argv", argv),
         mock.patch.object(webcam, "configure_logging"),
@@ -316,7 +318,7 @@ def test_main_uninstall_invokes_uninstall_service():
 
 
 def test_main_start_invokes_start_service():
-    argv = ["webcam.py", "--start", "--port", "7777"]
+    argv = ["webcam", "--start", "--port", "7777"]
     with (
         mock.patch.object(sys, "argv", argv),
         mock.patch.object(webcam, "configure_logging"),


### PR DESCRIPTION
## Summary
- update README references to webcam script
- load webcam module using SourceFileLoader
- adjust CLI tests to use the correct script name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bd61a0588333942f02f6df14e0fd