### PR TITLE
Add coverage support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source =
+    webcam
+omit =
+    tests/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install pytest pytest-cov pre-commit
+        python -m pip install pytest coverage pre-commit
     - name: Run pre-commit
       run: pre-commit run --show-diff-on-failure --color=always --all-files
     - name: Run tests with coverage
       shell: bash
       run: |
-        pytest --cov=webcam --cov-report=xml
+        coverage run -m pytest
+        coverage xml
+        coverage report
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       with:

--- a/README.md
+++ b/README.md
@@ -78,14 +78,16 @@ returns JSON with basic information.
 
 ## Development
 
-Run the unit tests with:
+Run the unit tests with coverage enabled using `coverage.py`:
 
 ```bash
-pytest
+pip install coverage  # once
+coverage run -m pytest
+coverage report
 ```
 
-The tests stub out system dependencies so they can run without a camera
-attached.
+This displays a coverage summary in the terminal. The tests stub out
+system dependencies so they can run without a camera attached.
 
 ## License
 


### PR DESCRIPTION
## Summary
- use coverage.py in CI
- document coverage workflow for developers
- add coverage configuration file

## Testing
- `pytest -q`
- `coverage run -m pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7358bc448333bb6718cf3443149e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a configuration file for code coverage measurement, focusing on the main source directory and excluding test files.
  * Updated test workflow to use the coverage tool for running tests and generating coverage reports.

* **Documentation**
  * Revised instructions in the README for running tests with code coverage, including detailed steps for generating and viewing coverage reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->