### PR TITLE
Add pinned dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Install Python dependencies with:
 pip install -r requirements.txt
 ```
 
+Dependencies are version-pinned for reproducible installs.
 
 ## Usage
 
 System packages may require your distribution's package manager, for
 example on Debian/Ubuntu:
-
 
 ```bash
 sudo apt install gphoto2 ffmpeg v4l2loopback-dkms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Flask
-opencv-python
+# Explicit versions ensure reproducible builds
+Flask==2.3.2
+opencv-python==4.8.1.78


### PR DESCRIPTION
## Summary
- pin Flask and opencv-python versions
- document that versions are pinned for reproducibility

## Testing
- `mypy .`
- `pytest -q`
- `bandit -r .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a734a2af483338648e9313f854202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify that Python dependencies are version-pinned for reproducible installs.

* **Chores**
  * Pinned Flask and opencv-python to specific versions in the requirements file to ensure consistent installations.
  * Added a comment in the requirements file explaining the use of explicit version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->