### PR TITLE
Merge duplicate Usage sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,9 @@ pip install -r requirements.txt
 System packages may require your distribution's package manager, for
 example on Debian/Ubuntu:
 
-
 ```bash
 sudo apt install gphoto2 ffmpeg v4l2loopback-dkms
 ```
-
-## Usage
 
 Run the script without arguments to start streaming:
 


### PR DESCRIPTION
## Summary
- combine adjacent Usage blocks in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a734be3108333946e6fc3e50a7032