### PR TITLE
Improve shutdown by removing sudo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ example on Debian/Ubuntu:
 sudo apt install gphoto2 ffmpeg v4l2loopback-dkms
 ```
 
-Run the script without arguments to start streaming:
+Run the script as root without arguments to start streaming:
 
 ```bash
-python3 webcam
+sudo python3 webcam
 ```
 
 The script accepts several options:
@@ -53,8 +53,9 @@ python3 webcam [--port PORT] [--start|--stop|--install|--uninstall]
                   [--log-file PATH] [--gphoto2 PATH] [--ffmpeg PATH]
 ```
 
-Most operations require interaction with system modules and may need
-root privileges. Use `sudo` when necessary.
+The application interacts with system modules such as `v4l2loopback`.
+Run it with root privileges (e.g. using `sudo`) so that cleanup works
+without password prompts.
 
 ### Service management
 

--- a/tests/test_webcam.py
+++ b/tests/test_webcam.py
@@ -92,8 +92,8 @@ def test_kill_existing_processes():
         with mock.patch.object(webcam.subprocess, "run") as m_run:
             webcam.kill_existing_processes(8000)
             m_co.assert_called_once_with(["lsof", "-i", ":8000"])
-            m_run.assert_any_call(["sudo", "kill", "-9", "1234"])
-            m_run.assert_any_call(["sudo", "kill", "-9", "5678"])
+            m_run.assert_any_call(["kill", "-9", "1234"])
+            m_run.assert_any_call(["kill", "-9", "5678"])
 
 
 def test_index_uses_template():
@@ -219,8 +219,8 @@ def test_install_service_writes_udev_rule():
             'ACTION=="remove", RUN+="/my/script --stop"'
         )
         handle.write.assert_called_once_with(expected + "\n")
-        m_run.assert_any_call(["sudo", "udevadm", "control", "--reload"])
-        m_run.assert_any_call(["sudo", "udevadm", "trigger"])
+        m_run.assert_any_call(["udevadm", "control", "--reload"])
+        m_run.assert_any_call(["udevadm", "trigger"])
 
 
 def test_uninstall_service_removes_udev_rule():
@@ -233,8 +233,8 @@ def test_uninstall_service_removes_udev_rule():
         webcam.uninstall_service()
         m_exists.assert_called_once_with("/etc/udev/rules.d/99-webcam.rules")
         m_remove.assert_called_once_with("/etc/udev/rules.d/99-webcam.rules")
-        m_run.assert_any_call(["sudo", "udevadm", "control", "--reload"])
-        m_run.assert_any_call(["sudo", "udevadm", "trigger"])
+        m_run.assert_any_call(["udevadm", "control", "--reload"])
+        m_run.assert_any_call(["udevadm", "trigger"])
 
 
 class FakeStderr:

--- a/webcam
+++ b/webcam
@@ -50,10 +50,10 @@ def setup_camera():
     global gphoto2_process, ffmpeg_process
 
     # Clean up any existing camera processes
-    subprocess.run(["sudo", "pkill", "-9", "gphoto2"], check=False)
-    subprocess.run(["sudo", "rmmod", "v4l2loopback"], check=False)
+    subprocess.run(["pkill", "-9", "gphoto2"], check=False)
+    subprocess.run(["rmmod", "v4l2loopback"], check=False)
     subprocess.run(
-        ["sudo", "modprobe", "v4l2loopback", "devices=1", "exclusive_caps=1"],
+        ["modprobe", "v4l2loopback", "devices=1", "exclusive_caps=1"],
         check=True,
     )
 
@@ -112,12 +112,12 @@ def cleanup_camera():
         logging.error(f"Error terminating ffmpeg process: {e}")
 
     try:
-        subprocess.run(["sudo", "pkill", "-9", "gphoto2"], check=False)
+        subprocess.run(["pkill", "-9", "gphoto2"], check=False)
         logging.info("gphoto2 cleaned up")
     except Exception as e:
         logging.error(f"Error running pkill on gphoto2: {e}")
     try:
-        subprocess.run(["sudo", "rmmod", "v4l2loopback"], check=False)
+        subprocess.run(["rmmod", "v4l2loopback"], check=False)
         logging.info("v4l2loopback cleaned up")
     except Exception as e:
         logging.error(f"Error cleaning up camera: {e}")
@@ -287,7 +287,7 @@ def kill_existing_processes(port):
         for line in lines:
             if "LISTEN" in line:
                 pid = line.split()[1]
-                subprocess.run(["sudo", "kill", "-9", pid])
+                subprocess.run(["kill", "-9", pid])
                 logging.info(f"Killed process {pid} on port {port}")
     except subprocess.CalledProcessError:
         logging.info(f"No process found on port {port}")
@@ -311,8 +311,8 @@ def install_service(script_path, vendor_id, product_id):
         print(f"Install complete: {udev_file}")
 
         # Reload udev rules
-        subprocess.run(["sudo", "udevadm", "control", "--reload"])
-        subprocess.run(["sudo", "udevadm", "trigger"])
+        subprocess.run(["udevadm", "control", "--reload"])
+        subprocess.run(["udevadm", "trigger"])
         logging.info("Udev rules reloaded")
         print("Udev rules reloaded")
 
@@ -335,8 +335,8 @@ def uninstall_service():
             print(f"Uninstall complete: {udev_file} removed")
 
             # Reload udev rules
-            subprocess.run(["sudo", "udevadm", "control", "--reload"])
-            subprocess.run(["sudo", "udevadm", "trigger"])
+            subprocess.run(["udevadm", "control", "--reload"])
+            subprocess.run(["udevadm", "trigger"])
             logging.info("Udev rules reloaded")
             print("Udev rules reloaded")
         else:


### PR DESCRIPTION
## Summary
- remove internal sudo usage to avoid password prompts
- update tests accordingly
- document running script as root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e3f0581bc83338f66cb4c0d393dba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README instructions to clarify the need for root privileges when running the streaming script and expanded the explanation regarding system module interaction and cleanup.

* **Bug Fixes**
  * Removed the use of "sudo" from system command executions within the application and corresponding tests, ensuring commands are run directly under the required privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->